### PR TITLE
feat: implement complete internationalization system

### DIFF
--- a/I18N_README.md
+++ b/I18N_README.md
@@ -1,0 +1,156 @@
+# Sistema de Internacionalización - ElurInfo
+
+## Idiomas Soportados
+
+La aplicación ahora soporta los siguientes idiomas:
+
+- 🇪🇸 **Español (es)** - Idioma por defecto
+- 🇬🇧 **English (en)** - Inglés
+- 🇫🇷 **Français (fr)** - Francés  
+- 🏴󠁥󠁳󠁣󠁴󠁿 **Català (ca)** - Catalán
+- 🏴󠁥󠁳󠁰󠁶󠁿 **Euskera (eu)** - Euskera/Vasco
+
+## Características Implementadas
+
+### 🔄 Detección Automática
+- Detecta automáticamente el idioma del navegador al primer acceso
+- Si el idioma del navegador no está soportado, usa español por defecto
+
+### 💾 Persistencia
+- La preferencia de idioma se guarda en localStorage
+- Se mantiene la selección entre sesiones del navegador
+
+### 🎛️ Selector de Idioma
+- Selector de idioma disponible en la página de Ajustes
+- Cambio instantáneo sin necesidad de recargar la página
+- Interfaz con banderas y nombres de idiomas
+
+### 🌐 Traducción Completa
+- Navegación (tabs): Mapa, Estaciones, Ajustes
+- Página de Mapa: título, subtítulo, leyenda de riesgos
+- Página de Estaciones: estados de carga, errores, contenido
+- Página de Ajustes: todas las opciones y configuraciones
+- Mensajes de estado: offline, loading, error, etc.
+
+## Estructura de Archivos
+
+```
+src/
+├── locales/
+│   ├── index.ts          # Configuración central y exportaciones
+│   ├── es.json          # Traducciones en español
+│   ├── en.json          # Traducciones en inglés
+│   ├── fr.json          # Traducciones en francés
+│   ├── ca.json          # Traducciones en catalán
+│   └── eu.json          # Traducciones en euskera
+├── composables/
+│   └── useLanguage.ts   # Composable para manejo de idiomas
+└── main.ts              # Configuración de Vue i18n
+```
+
+## Uso del Sistema
+
+### En Componentes Vue
+
+```vue
+<script setup>
+import { useLanguage } from '@/composables/useLanguage'
+
+const { t, currentLanguage, setLanguage } = useLanguage()
+</script>
+
+<template>
+  <h1>{{ t('settings.title') }}</h1>
+  <p>{{ t('settings.subtitle') }}</p>
+</template>
+```
+
+### Cambiar Idioma Programáticamente
+
+```typescript
+import { useLanguage } from '@/composables/useLanguage'
+
+const { setLanguage } = useLanguage()
+
+// Cambiar a inglés
+setLanguage('en')
+
+// Cambiar a catalán
+setLanguage('ca')
+```
+
+### Formateo de Fechas Localizadas
+
+```typescript
+const formatDate = (dateString: string): string => {
+  const date = new Date(dateString)
+  const locale = currentLanguage.value === 'ca' ? 'ca-ES' : 
+                currentLanguage.value === 'eu' ? 'eu-ES' :
+                currentLanguage.value === 'en' ? 'en-GB' :
+                currentLanguage.value === 'fr' ? 'fr-FR' : 'es-ES'
+  
+  return date.toLocaleDateString(locale, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short'
+  })
+}
+```
+
+## Añadir Nuevas Traducciones
+
+### 1. Añadir la Clave en los Archivos JSON
+
+En cada archivo de idioma (`es.json`, `en.json`, etc.), añadir la nueva clave:
+
+```json
+{
+  "newSection": {
+    "title": "Nuevo Título",
+    "description": "Nueva descripción"
+  }
+}
+```
+
+### 2. Usar en el Componente
+
+```vue
+<template>
+  <h2>{{ t('newSection.title') }}</h2>
+  <p>{{ t('newSection.description') }}</p>
+</template>
+```
+
+## Configuración Técnica
+
+### Vue i18n v9
+- Modo Composition API (legacy: false)
+- Idioma de fallback: español (es)
+- Detección automática del idioma del navegador
+- Persistencia en localStorage
+
+### Configuración en main.ts
+
+```typescript
+const i18n = createI18n({
+  legacy: false,
+  locale: defaultLanguage,
+  fallbackLocale: 'es',
+  messages
+})
+```
+
+## Mejoras Futuras
+
+- [ ] Añadir más idiomas (portugués, italiano, alemán)
+- [ ] Localización de números y monedas
+- [ ] Pluralización avanzada
+- [ ] Traducción dinámica de contenido del backend
+- [ ] Detección de dirección de texto (RTL/LTR)
+
+## Notas de Desarrollo
+
+- El backend mantiene los mensajes en español por ahora (para el MVP)
+- Los datos de las APIs (AEMET) se muestran en el idioma original
+- Las fechas y horas se formatean según el idioma seleccionado
+- El documento HTML se actualiza con el atributo `lang` correcto

--- a/elurInfo-FrontEnd/package-lock.json
+++ b/elurInfo-FrontEnd/package-lock.json
@@ -15,6 +15,7 @@
         "leaflet": "^1.9.4",
         "localforage": "^1.10.0",
         "vue": "^3.5.22",
+        "vue-i18n": "^9.14.5",
         "vue-router": "^4.4.5",
         "workbox-webpack-plugin": "^7.0.0"
       },
@@ -2038,6 +2039,50 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "9.14.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@ionic/cli-framework-output": {
@@ -7046,6 +7091,26 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/elurInfo-FrontEnd/package.json
+++ b/elurInfo-FrontEnd/package.json
@@ -9,21 +9,22 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@capacitor/app": "^7.0.1",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
-    "@capacitor/app": "^7.0.1",
     "@capacitor/network": "^7.0.1",
-    "vue": "^3.5.22",
-    "vue-router": "^4.4.5",
-    "localforage": "^1.10.0",
     "leaflet": "^1.9.4",
+    "localforage": "^1.10.0",
+    "vue": "^3.5.22",
+    "vue-i18n": "^9.14.5",
+    "vue-router": "^4.4.5",
     "workbox-webpack-plugin": "^7.0.0"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.12",
     "@types/node": "^24.6.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.8.1",
-    "@types/leaflet": "^1.9.12",
     "typescript": "~5.9.3",
     "vite": "^7.1.7",
     "vue-tsc": "^3.1.0"

--- a/elurInfo-FrontEnd/src/App.vue
+++ b/elurInfo-FrontEnd/src/App.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import TabLayout from './components/TabLayout.vue'
 import { useNetwork } from './composables/useNetwork'
+import { useLanguage } from './composables/useLanguage'
 
 const { connectionStatus } = useNetwork()
+const { t } = useLanguage()
 </script>
 
 <template>
   <div id="app" :class="{ 'has-offline-indicator': !connectionStatus.isOnline }">
     <!-- Offline indicator -->
     <div v-if="!connectionStatus.isOnline" class="offline-indicator">
-      📶 Modo offline - Mostrando datos guardados
+      {{ t('app.offline') }}
     </div>
 
     <TabLayout />

--- a/elurInfo-FrontEnd/src/components/TabLayout.vue
+++ b/elurInfo-FrontEnd/src/components/TabLayout.vue
@@ -23,30 +23,33 @@
 
 <script setup lang="ts">
 import { useRoute } from 'vue-router'
+import { computed } from 'vue'
+import { useLanguage } from '../composables/useLanguage'
 import type { TabItem } from '../types'
 
 const route = useRoute()
+const { t } = useLanguage()
 
-const tabs: TabItem[] = [
+const tabs = computed<TabItem[]>(() => [
   {
     id: 'mapa',
-    name: 'Mapa',
+    name: t('navigation.map'),
     path: '/mapa',
     icon: '🗺️'
   },
   {
     id: 'estaciones',
-    name: 'Estaciones',
+    name: t('navigation.stations'),
     path: '/estaciones',
     icon: '🏔️'
   },
   {
     id: 'ajustes',
-    name: 'Ajustes',
+    name: t('navigation.settings'),
     path: '/ajustes',
     icon: '⚙️'
   }
-]
+])
 </script>
 
 <style scoped>

--- a/elurInfo-FrontEnd/src/composables/useLanguage.ts
+++ b/elurInfo-FrontEnd/src/composables/useLanguage.ts
@@ -1,0 +1,42 @@
+import { computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { availableLocales } from '../locales'
+
+export function useLanguage() {
+  const { locale, t } = useI18n()
+
+  const currentLanguage = computed(() => locale.value)
+  
+  const currentLanguageInfo = computed(() => {
+    return availableLocales.find(lang => lang.code === locale.value) || availableLocales[0]
+  })
+
+  const setLanguage = (languageCode: string) => {
+    if (availableLocales.some(lang => lang.code === languageCode)) {
+      locale.value = languageCode
+      localStorage.setItem('elurinfo-language', languageCode)
+      
+      // Update document language attribute
+      document.documentElement.lang = languageCode
+    }
+  }
+
+  const getLanguageName = (code: string) => {
+    const lang = availableLocales.find(l => l.code === code)
+    return lang ? lang.name : code
+  }
+
+  // Watch for locale changes to update document language
+  watch(locale, (newLocale) => {
+    document.documentElement.lang = newLocale
+  }, { immediate: true })
+
+  return {
+    currentLanguage,
+    currentLanguageInfo,
+    availableLocales,
+    setLanguage,
+    getLanguageName,
+    t
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/ca.json
+++ b/elurInfo-FrontEnd/src/locales/ca.json
@@ -1,0 +1,94 @@
+{
+  "app": {
+    "offline": "📶 Mode fora de línia - Mostrant dades guardades",
+    "title": "ElurInfo"
+  },
+  "navigation": {
+    "map": "Mapa",
+    "stations": "Estacions",
+    "settings": "Configuració"
+  },
+  "map": {
+    "title": "Mapa d'Allaus",
+    "subtitle": "Serralada pirinenca",
+    "legend": {
+      "risk1": "Risc 1 - Dèbil",
+      "risk2": "Risc 2 - Limitat",
+      "risk3": "Risc 3 - Notable",
+      "risk4": "Risc 4 - Fort",
+      "risk5": "Risc 5 - Molt fort"
+    }
+  },
+  "stations": {
+    "title": "Estacions",
+    "subtitle": "Prediccions de muntanya",
+    "loading": "Carregant prediccions...",
+    "error": "Error en carregar les prediccions",
+    "retry": "Tornar a intentar",
+    "empty": "No hi ha prediccions disponibles",
+    "updated": "Actualitzat:",
+    "preview": "Veure detalls",
+    "forecastAvailable": "Predicció disponible"
+  },
+  "settings": {
+    "title": "Configuració",
+    "subtitle": "Configuració de l'aplicació",
+    "language": {
+      "title": "Idioma",
+      "label": "Idioma de l'aplicació"
+    },
+    "zone": {
+      "title": "Zona Favorita",
+      "label": "Zona per defecte",
+      "none": "Cap",
+      "aragon": "Pirineu Aragonès",
+      "navarre": "Pirineu Navarrès",
+      "catalonia": "Pirineu Català"
+    },
+    "updates": {
+      "title": "Actualització",
+      "auto": "Actualització automàtica",
+      "autoDescription": "Actualitzar dades automàticament quan estiguin disponibles",
+      "interval": "Interval d'actualització",
+      "intervals": {
+        "15": "15 minuts",
+        "30": "30 minuts",
+        "60": "1 hora",
+        "120": "2 hores"
+      }
+    },
+    "data": {
+      "title": "Dades",
+      "clear": "Netejar dades fora de línia",
+      "clearDescription": "Elimina totes les dades guardades localment",
+      "confirmClear": "Estàs segur que vols eliminar totes les dades fora de línia?",
+      "cleared": "Dades fora de línia eliminades correctament",
+      "clearError": "Error en eliminar les dades fora de línia"
+    },
+    "info": {
+      "title": "Informació",
+      "version": "Versió:",
+      "lastUpdate": "Última actualització:",
+      "connection": "Estat de la connexió:",
+      "online": "En línia",
+      "offline": "Fora de línia"
+    }
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "fr": "Français",
+    "ca": "Català",
+    "eu": "Euskera"
+  },
+  "common": {
+    "loading": "Carregant...",
+    "error": "Error",
+    "retry": "Tornar a intentar",
+    "save": "Desar",
+    "cancel": "Cancel·lar",
+    "ok": "D'acord",
+    "yes": "Sí",
+    "no": "No"
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/en.json
+++ b/elurInfo-FrontEnd/src/locales/en.json
@@ -1,0 +1,94 @@
+{
+  "app": {
+    "offline": "📶 Offline mode - Showing saved data",
+    "title": "ElurInfo"
+  },
+  "navigation": {
+    "map": "Map",
+    "stations": "Stations",
+    "settings": "Settings"
+  },
+  "map": {
+    "title": "Avalanche Map",
+    "subtitle": "Pyrenees range",
+    "legend": {
+      "risk1": "Risk 1 - Low",
+      "risk2": "Risk 2 - Limited",
+      "risk3": "Risk 3 - Considerable",
+      "risk4": "Risk 4 - High",
+      "risk5": "Risk 5 - Very High"
+    }
+  },
+  "stations": {
+    "title": "Stations",
+    "subtitle": "Mountain forecasts",
+    "loading": "Loading forecasts...",
+    "error": "Error loading forecasts",
+    "retry": "Retry",
+    "empty": "No forecasts available",
+    "updated": "Updated:",
+    "preview": "View details",
+    "forecastAvailable": "Forecast available"
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Application configuration",
+    "language": {
+      "title": "Language",
+      "label": "Application language"
+    },
+    "zone": {
+      "title": "Favorite Zone",
+      "label": "Default zone",
+      "none": "None",
+      "aragon": "Aragonese Pyrenees",
+      "navarre": "Navarrese Pyrenees",
+      "catalonia": "Catalan Pyrenees"
+    },
+    "updates": {
+      "title": "Updates",
+      "auto": "Automatic updates",
+      "autoDescription": "Automatically update data when available",
+      "interval": "Update interval",
+      "intervals": {
+        "15": "15 minutes",
+        "30": "30 minutes",
+        "60": "1 hour",
+        "120": "2 hours"
+      }
+    },
+    "data": {
+      "title": "Data",
+      "clear": "Clear offline data",
+      "clearDescription": "Remove all locally stored data",
+      "confirmClear": "Are you sure you want to delete all offline data?",
+      "cleared": "Offline data cleared successfully",
+      "clearError": "Error clearing offline data"
+    },
+    "info": {
+      "title": "Information",
+      "version": "Version:",
+      "lastUpdate": "Last update:",
+      "connection": "Connection status:",
+      "online": "Online",
+      "offline": "Offline"
+    }
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "fr": "Français",
+    "ca": "Català",
+    "eu": "Euskera"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Error",
+    "retry": "Retry",
+    "save": "Save",
+    "cancel": "Cancel",
+    "ok": "OK",
+    "yes": "Yes",
+    "no": "No"
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/es.json
+++ b/elurInfo-FrontEnd/src/locales/es.json
@@ -1,0 +1,94 @@
+{
+  "app": {
+    "offline": "📶 Modo offline - Mostrando datos guardados",
+    "title": "ElurInfo"
+  },
+  "navigation": {
+    "map": "Mapa",
+    "stations": "Estaciones",
+    "settings": "Ajustes"
+  },
+  "map": {
+    "title": "Mapa de Avalanchas",
+    "subtitle": "Cordillera pirenaica",
+    "legend": {
+      "risk1": "Riesgo 1 - Débil",
+      "risk2": "Riesgo 2 - Limitado", 
+      "risk3": "Riesgo 3 - Notable",
+      "risk4": "Riesgo 4 - Fuerte",
+      "risk5": "Riesgo 5 - Muy fuerte"
+    }
+  },
+  "stations": {
+    "title": "Estaciones",
+    "subtitle": "Predicciones de montaña",
+    "loading": "Cargando predicciones...",
+    "error": "Error al cargar las predicciones",
+    "retry": "Reintentar",
+    "empty": "No hay predicciones disponibles",
+    "updated": "Actualizado:",
+    "preview": "Ver detalles",
+    "forecastAvailable": "Predicción disponible"
+  },
+  "settings": {
+    "title": "Ajustes",
+    "subtitle": "Configuración de la aplicación",
+    "language": {
+      "title": "Idioma",
+      "label": "Idioma de la aplicación"
+    },
+    "zone": {
+      "title": "Zona Favorita",
+      "label": "Zona predeterminada",
+      "none": "Ninguna",
+      "aragon": "Pirineo Aragonés",
+      "navarre": "Pirineo Navarro",
+      "catalonia": "Pirineo Catalán"
+    },
+    "updates": {
+      "title": "Actualización",
+      "auto": "Actualización automática",
+      "autoDescription": "Actualizar datos automáticamente cuando esté disponible",
+      "interval": "Intervalo de actualización",
+      "intervals": {
+        "15": "15 minutos",
+        "30": "30 minutos", 
+        "60": "1 hora",
+        "120": "2 horas"
+      }
+    },
+    "data": {
+      "title": "Datos",
+      "clear": "Limpiar datos offline",
+      "clearDescription": "Elimina todos los datos guardados localmente",
+      "confirmClear": "¿Estás seguro de que quieres eliminar todos los datos offline?",
+      "cleared": "Datos offline eliminados correctamente",
+      "clearError": "Error al eliminar los datos offline"
+    },
+    "info": {
+      "title": "Información",
+      "version": "Versión:",
+      "lastUpdate": "Última actualización:",
+      "connection": "Estado de conexión:",
+      "online": "En línea",
+      "offline": "Sin conexión"
+    }
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "fr": "Français",
+    "ca": "Català",
+    "eu": "Euskera"
+  },
+  "common": {
+    "loading": "Cargando...",
+    "error": "Error",
+    "retry": "Reintentar",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "ok": "Aceptar",
+    "yes": "Sí",
+    "no": "No"
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/eu.json
+++ b/elurInfo-FrontEnd/src/locales/eu.json
@@ -1,0 +1,94 @@
+{
+  "app": {
+    "offline": "📶 Lineaz kanpoko modua - Gordetako datuak erakusten",
+    "title": "ElurInfo"
+  },
+  "navigation": {
+    "map": "Mapa",
+    "stations": "Estazioak",
+    "settings": "Ezarpenak"
+  },
+  "map": {
+    "title": "Elur-jausien Mapa",
+    "subtitle": "Pirinioetako mendilerroa",
+    "legend": {
+      "risk1": "1. Arriskua - Ahula",
+      "risk2": "2. Arriskua - Mugatua",
+      "risk3": "3. Arriskua - Nabaria",
+      "risk4": "4. Arriskua - Indartsu",
+      "risk5": "5. Arriskua - Oso indartsu"
+    }
+  },
+  "stations": {
+    "title": "Estazioak",
+    "subtitle": "Mendialdeko iragarpenak",
+    "loading": "Iragarpenak kargatzen...",
+    "error": "Errorea iragarpenak kargatzean",
+    "retry": "Berriz saiatu",
+    "empty": "Ez dago iragarpenik eskuragarri",
+    "updated": "Eguneratua:",
+    "preview": "Xehetasunak ikusi",
+    "forecastAvailable": "Iragarpena eskuragarri"
+  },
+  "settings": {
+    "title": "Ezarpenak",
+    "subtitle": "Aplikazioaren konfigurazioa",
+    "language": {
+      "title": "Hizkuntza",
+      "label": "Aplikazioaren hizkuntza"
+    },
+    "zone": {
+      "title": "Gustoko Zona",
+      "label": "Lehenetsitako zona",
+      "none": "Bat ere ez",
+      "aragon": "Aragoiko Pirinioak",
+      "navarre": "Nafarroako Pirinioak",
+      "catalonia": "Kataluniako Pirinioak"
+    },
+    "updates": {
+      "title": "Eguneraketa",
+      "auto": "Eguneraketa automatikoa",
+      "autoDescription": "Datuak automatikoki eguneratu eskuragarri dagoenean",
+      "interval": "Eguneraketa tartea",
+      "intervals": {
+        "15": "15 minutu",
+        "30": "30 minutu",
+        "60": "Ordu 1",
+        "120": "2 ordu"
+      }
+    },
+    "data": {
+      "title": "Datuak",
+      "clear": "Lineaz kanpoko datuak garbitu",
+      "clearDescription": "Lokalki gordetako datu guztiak ezabatu",
+      "confirmClear": "Ziur zaude lineaz kanpoko datu guztiak ezabatu nahi dituzula?",
+      "cleared": "Lineaz kanpoko datuak behar bezala ezabatu dira",
+      "clearError": "Errorea lineaz kanpoko datuak ezabatzean"
+    },
+    "info": {
+      "title": "Informazioa",
+      "version": "Bertsioa:",
+      "lastUpdate": "Azken eguneraketa:",
+      "connection": "Konexioaren egoera:",
+      "online": "Linean",
+      "offline": "Lineaz kanpo"
+    }
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "fr": "Français",
+    "ca": "Català",
+    "eu": "Euskera"
+  },
+  "common": {
+    "loading": "Kargatzen...",
+    "error": "Errorea",
+    "retry": "Berriz saiatu",
+    "save": "Gorde",
+    "cancel": "Utzi",
+    "ok": "Ados",
+    "yes": "Bai",
+    "no": "Ez"
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/fr.json
+++ b/elurInfo-FrontEnd/src/locales/fr.json
@@ -1,0 +1,94 @@
+{
+  "app": {
+    "offline": "📶 Mode hors ligne - Affichage des données sauvegardées",
+    "title": "ElurInfo"
+  },
+  "navigation": {
+    "map": "Carte",
+    "stations": "Stations",
+    "settings": "Paramètres"
+  },
+  "map": {
+    "title": "Carte d'Avalanches",
+    "subtitle": "Chaîne des Pyrénées",
+    "legend": {
+      "risk1": "Risque 1 - Faible",
+      "risk2": "Risque 2 - Limité",
+      "risk3": "Risque 3 - Notable",
+      "risk4": "Risque 4 - Fort",
+      "risk5": "Risque 5 - Très fort"
+    }
+  },
+  "stations": {
+    "title": "Stations",
+    "subtitle": "Prévisions de montagne",
+    "loading": "Chargement des prévisions...",
+    "error": "Erreur lors du chargement des prévisions",
+    "retry": "Réessayer",
+    "empty": "Aucune prévision disponible",
+    "updated": "Mis à jour :",
+    "preview": "Voir les détails",
+    "forecastAvailable": "Prévision disponible"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "subtitle": "Configuration de l'application",
+    "language": {
+      "title": "Langue",
+      "label": "Langue de l'application"
+    },
+    "zone": {
+      "title": "Zone Favorite",
+      "label": "Zone par défaut",
+      "none": "Aucune",
+      "aragon": "Pyrénées Aragonaises",
+      "navarre": "Pyrénées Navarraises",
+      "catalonia": "Pyrénées Catalanes"
+    },
+    "updates": {
+      "title": "Mise à jour",
+      "auto": "Mise à jour automatique",
+      "autoDescription": "Mettre à jour automatiquement les données lorsqu'elles sont disponibles",
+      "interval": "Intervalle de mise à jour",
+      "intervals": {
+        "15": "15 minutes",
+        "30": "30 minutes",
+        "60": "1 heure",
+        "120": "2 heures"
+      }
+    },
+    "data": {
+      "title": "Données",
+      "clear": "Effacer les données hors ligne",
+      "clearDescription": "Supprimer toutes les données stockées localement",
+      "confirmClear": "Êtes-vous sûr de vouloir supprimer toutes les données hors ligne ?",
+      "cleared": "Données hors ligne supprimées avec succès",
+      "clearError": "Erreur lors de la suppression des données hors ligne"
+    },
+    "info": {
+      "title": "Information",
+      "version": "Version :",
+      "lastUpdate": "Dernière mise à jour :",
+      "connection": "État de la connexion :",
+      "online": "En ligne",
+      "offline": "Hors ligne"
+    }
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "fr": "Français",
+    "ca": "Català",
+    "eu": "Euskera"
+  },
+  "common": {
+    "loading": "Chargement...",
+    "error": "Erreur",
+    "retry": "Réessayer",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "ok": "OK",
+    "yes": "Oui",
+    "no": "Non"
+  }
+}

--- a/elurInfo-FrontEnd/src/locales/index.ts
+++ b/elurInfo-FrontEnd/src/locales/index.ts
@@ -1,0 +1,21 @@
+import es from './es.json'
+import en from './en.json'
+import fr from './fr.json'
+import ca from './ca.json'
+import eu from './eu.json'
+
+export const messages = {
+  es,
+  en,
+  fr,
+  ca,
+  eu
+}
+
+export const availableLocales = [
+  { code: 'es', name: 'Español', flag: '🇪🇸' },
+  { code: 'en', name: 'English', flag: '🇬🇧' },
+  { code: 'fr', name: 'Français', flag: '🇫🇷' },
+  { code: 'ca', name: 'Català', flag: '🏴󠁥󠁳󠁣󠁴󠁿' },
+  { code: 'eu', name: 'Euskera', flag: '🏴󠁥󠁳󠁰󠁶󠁿' }
+]

--- a/elurInfo-FrontEnd/src/main.ts
+++ b/elurInfo-FrontEnd/src/main.ts
@@ -1,11 +1,30 @@
 import { createApp } from 'vue'
+import { createI18n } from 'vue-i18n'
 import './style.css'
 import App from './App.vue'
 import router from './router'
 import { serviceWorkerService } from './services/serviceWorker.service'
+import { messages } from './locales'
+
+// Get saved language from localStorage or default to browser language
+const savedLanguage = localStorage.getItem('elurinfo-language')
+const browserLanguage = navigator.language.split('-')[0] || 'es'
+const defaultLanguage = savedLanguage && Object.keys(messages).includes(savedLanguage) 
+  ? savedLanguage 
+  : Object.keys(messages).includes(browserLanguage) 
+    ? browserLanguage 
+    : 'es'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: defaultLanguage,
+  fallbackLocale: 'es',
+  messages
+})
 
 const app = createApp(App)
 app.use(router)
+app.use(i18n)
 app.mount('#app')
 
 // Register Service Worker

--- a/elurInfo-FrontEnd/src/pages/MapPage.vue
+++ b/elurInfo-FrontEnd/src/pages/MapPage.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="map-page">
     <div class="page-header">
-      <h1>Mapa de Avalanchas</h1>
-      <p class="subtitle">Cordillera pirenaica</p>
+      <h1>{{ t('map.title') }}</h1>
+      <p class="subtitle">{{ t('map.subtitle') }}</p>
     </div>
     
     <div class="map-container" ref="mapContainer">
@@ -12,23 +12,23 @@
     <div class="map-legend">
       <div class="legend-item">
         <span class="legend-color risk-1"></span>
-        <span>Riesgo 1 - Débil</span>
+        <span>{{ t('map.legend.risk1') }}</span>
       </div>
       <div class="legend-item">
         <span class="legend-color risk-2"></span>
-        <span>Riesgo 2 - Limitado</span>
+        <span>{{ t('map.legend.risk2') }}</span>
       </div>
       <div class="legend-item">
         <span class="legend-color risk-3"></span>
-        <span>Riesgo 3 - Notable</span>
+        <span>{{ t('map.legend.risk3') }}</span>
       </div>
       <div class="legend-item">
         <span class="legend-color risk-4"></span>
-        <span>Riesgo 4 - Fuerte</span>
+        <span>{{ t('map.legend.risk4') }}</span>
       </div>
       <div class="legend-item">
         <span class="legend-color risk-5"></span>
-        <span>Riesgo 5 - Muy fuerte</span>
+        <span>{{ t('map.legend.risk5') }}</span>
       </div>
     </div>
   </div>
@@ -37,9 +37,11 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useAvalancheMap } from '../composables/useAvalancheMap'
+import { useLanguage } from '../composables/useLanguage'
 
 const mapContainer = ref<HTMLElement>()
 const { initializeMap, destroyMap } = useAvalancheMap()
+const { t } = useLanguage()
 
 onMounted(() => {
   if (mapContainer.value) {

--- a/elurInfo-FrontEnd/src/pages/SettingsPage.vue
+++ b/elurInfo-FrontEnd/src/pages/SettingsPage.vue
@@ -1,56 +1,56 @@
 <template>
   <div class="settings-page">
     <div class="page-header">
-      <h1>Ajustes</h1>
-      <p class="subtitle">Configuración de la aplicación</p>
+      <h1>{{ t('settings.title') }}</h1>
+      <p class="subtitle">{{ t('settings.subtitle') }}</p>
     </div>
     
     <div class="settings-content">
       <div class="settings-section">
-        <h2>Idioma</h2>
+        <h2>{{ t('settings.language.title') }}</h2>
         <div class="settings-section-content">
           <div class="setting-item">
-            <label for="language-select">Idioma de la aplicación</label>
+            <label for="language-select">{{ t('settings.language.label') }}</label>
             <select 
               id="language-select"
-              v-model="settings.language"
-              @change="saveSettings"
+              :value="settings.language"
+              @change="onLanguageChange(($event.target as HTMLSelectElement).value)"
               class="setting-select"
             >
-              <option value="es">Español</option>
-              <option value="ca">Català</option>
-              <option value="eu">Euskera</option>
+              <option v-for="locale in availableLocales" :key="locale.code" :value="locale.code">
+                {{ locale.flag }} {{ locale.name }}
+              </option>
             </select>
           </div>
         </div>
       </div>
 
       <div class="settings-section">
-        <h2>Zona Favorita</h2>
+        <h2>{{ t('settings.zone.title') }}</h2>
         <div class="settings-section-content">
           <div class="setting-item">
-            <label for="zone-select">Zona predeterminada</label>
+            <label for="zone-select">{{ t('settings.zone.label') }}</label>
             <select 
               id="zone-select"
               v-model="settings.favoriteZone"
               @change="saveSettings"
               class="setting-select"
             >
-              <option value="">Ninguna</option>
-              <option value="pirineo-aragones">Pirineo Aragonés</option>
-              <option value="pirineo-navarro">Pirineo Navarro</option>
-              <option value="pirineo-catalan">Pirineo Catalán</option>
+              <option value="">{{ t('settings.zone.none') }}</option>
+              <option value="pirineo-aragones">{{ t('settings.zone.aragon') }}</option>
+              <option value="pirineo-navarro">{{ t('settings.zone.navarre') }}</option>
+              <option value="pirineo-catalan">{{ t('settings.zone.catalonia') }}</option>
             </select>
           </div>
         </div>
       </div>
 
       <div class="settings-section">
-        <h2>Actualización</h2>
+        <h2>{{ t('settings.updates.title') }}</h2>
         <div class="settings-section-content">
           <div class="setting-item">
             <div class="setting-toggle">
-              <label for="auto-refresh">Actualización automática</label>
+              <label for="auto-refresh">{{ t('settings.updates.auto') }}</label>
               <input 
                 id="auto-refresh"
                 type="checkbox" 
@@ -61,57 +61,57 @@
               <span class="toggle-slider"></span>
             </div>
             <p class="setting-description">
-              Actualizar datos automáticamente cuando esté disponible
+              {{ t('settings.updates.autoDescription') }}
             </p>
           </div>
           
           <div v-if="settings.autoRefresh" class="setting-item">
-            <label for="refresh-interval">Intervalo de actualización</label>
+            <label for="refresh-interval">{{ t('settings.updates.interval') }}</label>
             <select 
               id="refresh-interval"
               v-model="settings.refreshInterval"
               @change="saveSettings"
               class="setting-select"
             >
-              <option :value="15">15 minutos</option>
-              <option :value="30">30 minutos</option>
-              <option :value="60">1 hora</option>
-              <option :value="120">2 horas</option>
+              <option :value="15">{{ t('settings.updates.intervals.15') }}</option>
+              <option :value="30">{{ t('settings.updates.intervals.30') }}</option>
+              <option :value="60">{{ t('settings.updates.intervals.60') }}</option>
+              <option :value="120">{{ t('settings.updates.intervals.120') }}</option>
             </select>
           </div>
         </div>
       </div>
 
       <div class="settings-section">
-        <h2>Datos</h2>
+        <h2>{{ t('settings.data.title') }}</h2>
         <div class="settings-section-content">
           <div class="setting-item">
             <button @click="clearOfflineData" class="danger-button">
-              Limpiar datos offline
+              {{ t('settings.data.clear') }}
             </button>
             <p class="setting-description">
-              Elimina todos los datos guardados localmente
+              {{ t('settings.data.clearDescription') }}
             </p>
           </div>
         </div>
       </div>
 
       <div class="settings-section">
-        <h2>Información</h2>
+        <h2>{{ t('settings.info.title') }}</h2>
         <div class="settings-section-content">
           <div class="info-list">
             <div class="info-item">
-              <span class="info-label">Versión:</span>
+              <span class="info-label">{{ t('settings.info.version') }}</span>
               <span class="info-value">1.0.0</span>
             </div>
             <div class="info-item">
-              <span class="info-label">Última actualización:</span>
+              <span class="info-label">{{ t('settings.info.lastUpdate') }}</span>
               <span class="info-value">{{ lastUpdate }}</span>
             </div>
             <div class="info-item">
-              <span class="info-label">Estado de conexión:</span>
+              <span class="info-label">{{ t('settings.info.connection') }}</span>
               <span class="info-value" :class="connectionClass">
-                {{ isOnline() ? 'En línea' : 'Sin conexión' }}
+                {{ isOnline() ? t('settings.info.online') : t('settings.info.offline') }}
               </span>
             </div>
           </div>
@@ -125,14 +125,16 @@
 import { computed } from 'vue'
 import { useSettings } from '../composables/useSettings'
 import { useNetwork } from '../composables/useNetwork'
+import { useLanguage } from '../composables/useLanguage'
 import { offlineService } from '../services/offline.service'
 
 const { settings, saveSettings, loadSettings } = useSettings()
 const { isOnline } = useNetwork()
+const { t, availableLocales, setLanguage } = useLanguage()
 
 const lastUpdate = computed(() => {
   // TODO: Get real last update time from stored data
-  return new Date().toLocaleString('es-ES')
+  return new Date().toLocaleString()
 })
 
 const connectionClass = computed(() => {
@@ -140,15 +142,21 @@ const connectionClass = computed(() => {
 })
 
 const clearOfflineData = async () => {
-  if (confirm('¿Estás seguro de que quieres eliminar todos los datos offline?')) {
+  if (confirm(t('settings.data.confirmClear'))) {
     try {
       await offlineService.clearAllData()
-      alert('Datos offline eliminados correctamente')
+      alert(t('settings.data.cleared'))
     } catch (error) {
       console.error('Error clearing offline data:', error)
-      alert('Error al eliminar los datos offline')
+      alert(t('settings.data.clearError'))
     }
   }
+}
+
+const onLanguageChange = (languageCode: string) => {
+  setLanguage(languageCode)
+  settings.language = languageCode as 'es' | 'en' | 'fr' | 'ca' | 'eu'
+  saveSettings()
 }
 
 // Load settings on mount

--- a/elurInfo-FrontEnd/src/pages/StationsPage.vue
+++ b/elurInfo-FrontEnd/src/pages/StationsPage.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="stations-page">
     <div class="page-header">
-      <h1>Estaciones</h1>
-      <p class="subtitle">Predicciones de montaña</p>
+      <h1>{{ t('stations.title') }}</h1>
+      <p class="subtitle">{{ t('stations.subtitle') }}</p>
     </div>
     
     <div class="stations-content">
       <!-- Loading state -->
       <div v-if="loading" class="loading-state">
         <div class="spinner"></div>
-        <p>Cargando predicciones...</p>
+        <p>{{ t('stations.loading') }}</p>
       </div>
       
       <!-- Error state -->
@@ -17,7 +17,7 @@
         <span class="error-icon">⚠️</span>
         <p>{{ error }}</p>
         <button @click="loadForecasts" class="retry-button">
-          Reintentar
+          {{ t('stations.retry') }}
         </button>
       </div>
       
@@ -40,7 +40,7 @@
           
           <div class="forecast-meta">
             <span class="update-time">
-              Actualizado: {{ formatTime(forecast.last_update) }}
+              {{ t('stations.updated') }} {{ formatTime(forecast.last_update) }}
             </span>
           </div>
         </div>
@@ -49,7 +49,7 @@
       <!-- Empty state -->
       <div v-if="!loading && !error && forecasts.length === 0" class="empty-state">
         <span class="empty-icon">🏔️</span>
-        <p>No hay predicciones disponibles</p>
+        <p>{{ t('stations.empty') }}</p>
       </div>
     </div>
     
@@ -67,6 +67,7 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import { useMountainForecasts } from '../composables/useMountainForecasts'
+import { useLanguage } from '../composables/useLanguage'
 
 const { 
   forecasts, 
@@ -76,13 +77,20 @@ const {
   selectForecast 
 } = useMountainForecasts()
 
+const { t, currentLanguage } = useLanguage()
+
 onMounted(() => {
   loadForecasts()
 })
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString)
-  return date.toLocaleDateString('es-ES', {
+  const locale = currentLanguage.value === 'ca' ? 'ca-ES' : 
+                currentLanguage.value === 'eu' ? 'eu-ES' :
+                currentLanguage.value === 'en' ? 'en-GB' :
+                currentLanguage.value === 'fr' ? 'fr-FR' : 'es-ES'
+  
+  return date.toLocaleDateString(locale, {
     weekday: 'short',
     day: 'numeric',
     month: 'short'
@@ -91,7 +99,12 @@ const formatDate = (dateString: string): string => {
 
 const formatTime = (dateString: string): string => {
   const date = new Date(dateString)
-  return date.toLocaleTimeString('es-ES', {
+  const locale = currentLanguage.value === 'ca' ? 'ca-ES' : 
+                currentLanguage.value === 'eu' ? 'eu-ES' :
+                currentLanguage.value === 'en' ? 'en-GB' :
+                currentLanguage.value === 'fr' ? 'fr-FR' : 'es-ES'
+  
+  return date.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit'
   })
@@ -101,9 +114,9 @@ const getPreviewText = (forecastJson: string): string => {
   try {
     const data = JSON.parse(forecastJson)
     // Extract relevant preview information
-    return data.descripcion || data.resumen || 'Predicción disponible'
+    return data.descripcion || data.resumen || t('stations.forecastAvailable')
   } catch {
-    return 'Ver detalles'
+    return t('stations.preview')
   }
 }
 </script>

--- a/elurInfo-FrontEnd/src/services/municipal.service.ts
+++ b/elurInfo-FrontEnd/src/services/municipal.service.ts
@@ -1,5 +1,3 @@
-import type { MunicipalForecast } from '../types'
-
 interface Municipality {
   id: string
   name: string

--- a/elurInfo-FrontEnd/src/types/index.ts
+++ b/elurInfo-FrontEnd/src/types/index.ts
@@ -42,7 +42,7 @@ export interface TabItem {
 }
 
 export interface AppSettings {
-  language: 'es' | 'ca' | 'eu'
+  language: 'es' | 'en' | 'fr' | 'ca' | 'eu'
   favoriteZone: string
   autoRefresh: boolean
   refreshInterval: number


### PR DESCRIPTION
- Add support for 5 languages: Spanish, English, French, Catalan, Euskera
- Install and configure Vue i18n v9 with Composition API
- Create translation files for all supported languages
- Add useLanguage composable for language management
- Update all components to use translations instead of hardcoded text
- Implement language selector in settings page with flags
- Add automatic browser language detection
- Persist language preference in localStorage
- Localize date/time formatting per language
- Update TypeScript types to support all languages
- Add comprehensive I18N documentation

Closes: language support requirements